### PR TITLE
feat: support KeyShares and KeyThreshold in the configuration

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.20.0-dev.1
+version: 1.20.0-dev.2
 appVersion: 1.19.0
 description: Kubernetes operator for Hashicorp Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-operator/crds/crd.yaml
+++ b/charts/vault-operator/crds/crd.yaml
@@ -1152,6 +1152,10 @@ spec:
                     type: object
                   kubernetes:
                     properties:
+                      keyShares:
+                        type: integer
+                      keyThreshold:
+                        type: integer
                       secretName:
                         type: string
                       secretNamespace:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1152,6 +1152,10 @@ spec:
                     type: object
                   kubernetes:
                     properties:
+                      keyShares:
+                        type: integer
+                      keyThreshold:
+                        type: integer
                       secretName:
                         type: string
                       secretNamespace:

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -947,6 +947,21 @@ func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 			strings.Join(secretLabels, ","),
 		)
 
+		// Same defaults as in Vault
+		shares, threshold := 5, 3
+		if usc.Kubernetes.KeyShares != nil && *usc.Kubernetes.KeyShares >= 1 {
+			shares = *usc.Kubernetes.KeyShares
+		}
+		if usc.Kubernetes.KeyThreshold != nil && *usc.Kubernetes.KeyThreshold >= 1 {
+			threshold = *usc.Kubernetes.KeyThreshold
+		}
+
+		args = append(args,
+			"--secret-shares",
+			fmt.Sprint(shares),
+			"--secret-threshold",
+			fmt.Sprint(threshold),
+		)
 	}
 
 	return args
@@ -961,6 +976,8 @@ func (usc *UnsealConfig) HSMDaemonNeeded() bool {
 type KubernetesUnsealConfig struct {
 	SecretNamespace string `json:"secretNamespace,omitempty"`
 	SecretName      string `json:"secretName,omitempty"`
+	KeyShares       *int   `json:"keyShares,omitempty"`
+	KeyThreshold    *int   `json:"keyThreshold,omitempty"`
 }
 
 // GoogleUnsealConfig holds the parameters for Google KMS based unsealing
@@ -973,7 +990,8 @@ type GoogleUnsealConfig struct {
 }
 
 // AlibabaUnsealConfig holds the parameters for Alibaba Cloud KMS based unsealing
-//  --alibaba-kms-region eu-central-1 --alibaba-kms-key-id 9d8063eb-f9dc-421b-be80-15d195c9f148 --alibaba-oss-endpoint oss-eu-central-1.aliyuncs.com --alibaba-oss-bucket bank-vaults
+//
+//	--alibaba-kms-region eu-central-1 --alibaba-kms-key-id 9d8063eb-f9dc-421b-be80-15d195c9f148 --alibaba-oss-endpoint oss-eu-central-1.aliyuncs.com --alibaba-oss-bucket bank-vaults
 type AlibabaUnsealConfig struct {
 	KMSRegion   string `json:"kmsRegion"`
 	KMSKeyID    string `json:"kmsKeyId"`


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

New UnsealConfig parameters, `KeyShares` and `KeyThreshold` that are exposed in the CRD. Sets the corresponding arg flags for bank-vaults container.

Fixes #56 

## Notes for reviewer

<!-- Anything the reviewer should know? -->

I decided not to validate the user input (except >= 1), as seem to be the norm elsewhere in the `ToArgs()` function. The `bank-vaults` binary has some sanity checks later in the flow.

I put the new parameters under `KubernetesUnsealConfig` since I believe auto-unseal options can't utilize this functionality. But I'm not 100% sure about this, please correct me if I'm wrong.
