### PR TITLE
Allows users to specify unseal key shares and key threshold 

### DIFF
--- a/charts/vault-operator/crds/crd.yaml
+++ b/charts/vault-operator/crds/crd.yaml
@@ -1163,6 +1163,10 @@ spec:
                         type: boolean
                       storeRootToken:
                         type: boolean
+                      secretShares:
+                        type: integer
+                      secretThreshold:
+                        type: integer
                     type: object
                   vault:
                     properties:

--- a/deploy/cr-awskms.yaml
+++ b/deploy/cr-awskms.yaml
@@ -39,6 +39,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-file.yaml
+++ b/deploy/cr-file.yaml
@@ -33,6 +33,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-gcpkms.yaml
+++ b/deploy/cr-gcpkms.yaml
@@ -37,6 +37,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-init-containers.yaml
+++ b/deploy/cr-init-containers.yaml
@@ -116,6 +116,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-k8s-startup-secret.yaml
+++ b/deploy/cr-k8s-startup-secret.yaml
@@ -92,6 +92,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-oidc.yaml
+++ b/deploy/cr-oidc.yaml
@@ -49,6 +49,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-priority.yaml
+++ b/deploy/cr-priority.yaml
@@ -98,6 +98,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr-raft.yaml
+++ b/deploy/cr-raft.yaml
@@ -121,6 +121,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -106,6 +106,12 @@ spec:
       # The storeRootToken flag enables storing of root token in chosen storage
       # This is true by default
       storeRootToken: true
+      # The secretShares represents the total number of unseal key shares
+      # This is 5 by default
+      secretShares: 5
+      # The secretThreshold represents the minimum number of shares required to reconstruct the unseal key
+      # This is 3 by default
+      secretThreshold: 3
     kubernetes:
       secretNamespace: default
 

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1163,6 +1163,10 @@ spec:
                         type: boolean
                       storeRootToken:
                         type: boolean
+                      secretShares:
+                        type: integer
+                      secretThreshold:
+                        type: integer
                     type: object
                   vault:
                     properties:

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -765,6 +765,8 @@ type UnsealConfig struct {
 type UnsealOptions struct {
 	PreFlightChecks *bool `json:"preFlightChecks,omitempty"`
 	StoreRootToken  *bool `json:"storeRootToken,omitempty"`
+	SecretThreshold *uint `json:"secretThreshold,omitempty"`
+	SecretShares    *uint `json:"secretShares,omitempty"`
 }
 
 // ToArgs returns the UnsealConfig as and argument array for bank-vaults
@@ -778,6 +780,16 @@ func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 	// StoreRootToken is true by default
 	if usc.Options.StoreRootToken != nil && !*usc.Options.StoreRootToken {
 		args = append(args, "--store-root-token=false")
+	}
+
+	// SecretShares is 5 by default
+	if usc.Options.SecretShares != nil && *usc.Options.SecretShares > 0 {
+		args = append(args, "--secret-shares", fmt.Sprint(*usc.Options.SecretShares))
+	}
+
+	// SecretThreshold is 3 by default
+	if usc.Options.SecretThreshold != nil && *usc.Options.SecretThreshold > 0 {
+		args = append(args, "--secret-threshold", fmt.Sprint(*usc.Options.SecretThreshold))
 	}
 
 	if usc.Google != nil {
@@ -973,7 +985,8 @@ type GoogleUnsealConfig struct {
 }
 
 // AlibabaUnsealConfig holds the parameters for Alibaba Cloud KMS based unsealing
-//  --alibaba-kms-region eu-central-1 --alibaba-kms-key-id 9d8063eb-f9dc-421b-be80-15d195c9f148 --alibaba-oss-endpoint oss-eu-central-1.aliyuncs.com --alibaba-oss-bucket bank-vaults
+//
+//	--alibaba-kms-region eu-central-1 --alibaba-kms-key-id 9d8063eb-f9dc-421b-be80-15d195c9f148 --alibaba-oss-endpoint oss-eu-central-1.aliyuncs.com --alibaba-oss-bucket bank-vaults
 type AlibabaUnsealConfig struct {
 	KMSRegion   string `json:"kmsRegion"`
 	KMSKeyID    string `json:"kmsKeyId"`


### PR DESCRIPTION
## Overview

Allows users to specify unseal key shares and key threshold based on their specific requirements. The changes in this pull request also include modifications to the Custom Resource Definitions (CRDs), a version bump, and updates to a few example deployment YAML files.

Fixes #56

## Notes for reviewer

This pull request introduces a different approach compared to [PR-57](https://github.com/bank-vaults/vault-operator/pull/57), as this is mode independent(not just Kubernetes specific). Users will have the flexibility to utilize the `options` field in `UnsealConfig` to specify their desired values.
Thank you :) 