### PR TITLE
feat: Add configurable AWS KMS encryption context

### DIFF
--- a/deploy/charts/vault-operator/crds/crd.yaml
+++ b/deploy/charts/vault-operator/crds/crd.yaml
@@ -1088,6 +1088,8 @@ spec:
                     type: object
                   aws:
                     properties:
+                      kmsEncryptionContext:
+                        type: string
                       kmsKeyId:
                         type: string
                       kmsRegion:

--- a/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
+++ b/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
@@ -1088,6 +1088,8 @@ spec:
                     type: object
                   aws:
                     properties:
+                      kmsEncryptionContext:
+                        type: string
                       kmsKeyId:
                         type: string
                       kmsRegion:

--- a/deploy/examples/cr-aws.yaml
+++ b/deploy/examples/cr-aws.yaml
@@ -16,6 +16,7 @@ spec:
     aws:
       kmsKeyId: "9f054126-2a98-470c-9f10-9b3b0cad94a1"
       kmsRegion: "eu-west-1"
+      kmsEncryptionContext: "Service=Vault"
       s3Bucket: "bank-vaults"
       s3Prefix: "vault-operator/"
       s3Region: "eu-west-1"

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -704,6 +704,8 @@ func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 			usc.AWS.KMSKeyID,
 			"--aws-kms-region",
 			usc.AWS.KMSRegion,
+			"--aws-kms-encryption-context",
+			usc.AWS.KMSEncryptionContext,
 			"--aws-s3-bucket",
 			usc.AWS.S3Bucket,
 			"--aws-s3-prefix",
@@ -879,12 +881,13 @@ type AzureUnsealConfig struct {
 
 // AWSUnsealConfig holds the parameters for AWS KMS based unsealing
 type AWSUnsealConfig struct {
-	KMSKeyID  string `json:"kmsKeyId"`
-	KMSRegion string `json:"kmsRegion,omitempty"`
-	S3Bucket  string `json:"s3Bucket"`
-	S3Prefix  string `json:"s3Prefix"`
-	S3Region  string `json:"s3Region,omitempty"`
-	S3SSE     string `json:"s3SSE,omitempty"`
+	KMSKeyID             string `json:"kmsKeyId"`
+	KMSRegion            string `json:"kmsRegion,omitempty"`
+	KMSEncryptionContext string `json:"kmsEncryptionContext,omitempty"`
+	S3Bucket             string `json:"s3Bucket"`
+	S3Prefix             string `json:"s3Prefix"`
+	S3Region             string `json:"s3Region,omitempty"`
+	S3SSE                string `json:"s3SSE,omitempty"`
 }
 
 // VaultUnsealConfig holds the parameters for remote Vault based unsealing


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Features:

This PR is created in order to allow the vault operator to take advantage of [this](https://github.com/banzaicloud/bank-vaults/pull/1968) bank-vaults feature

## Notes for reviewer

In our use case, we have an existing vault cluster that has existing unseal keys that are encrypted with a custom encryption context. This feature will allow us to migrate this vault cluster to be managed by bank-vaults.
