### PR TITLE
chore: Use verified publisher image `hashicorp/vault`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,10 @@ import-image: docker-build ## Import manager image to kind image repository
 .PHONY: import-test
 import-test: import-image ## Import images required for tests to kind image repository
 	docker pull ghcr.io/banzaicloud/bank-vaults:$(TEST_BANK_VAULTS_VERSION)
-	docker pull vault:$(TEST_VAULT_VERSION)
+	docker pull hashicorp/vault:$(TEST_VAULT_VERSION)
 
 	$(KIND) load docker-image ghcr.io/banzaicloud/bank-vaults:$(TEST_BANK_VAULTS_VERSION) --name $(TEST_KIND_CLUSTER)
-	$(KIND) load docker-image vault:$(TEST_VAULT_VERSION) --name $(TEST_KIND_CLUSTER)
+	$(KIND) load docker-image hashicorp/vault:$(TEST_VAULT_VERSION) --name $(TEST_KIND_CLUSTER)
 
 ##@ Build
 

--- a/deploy/dev/microk8s/dev.yaml
+++ b/deploy/dev/microk8s/dev.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault-dev
 spec:
   size: 1
-  image: docker.io/library/vault:dev-ui
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:<branch_name>
 
   # Common annotations for all created resources

--- a/deploy/dev/multi-dc/aws/cr-primary.yaml
+++ b/deploy/dev/multi-dc/aws/cr-primary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-primary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/aws/cr-secondary.yaml
+++ b/deploy/dev/multi-dc/aws/cr-secondary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-secondary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/aws/cr-tertiary.yaml
+++ b/deploy/dev/multi-dc/aws/cr-tertiary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-tertiary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/test/cr-primary.yaml
+++ b/deploy/dev/multi-dc/test/cr-primary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-primary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/test/cr-secondary.yaml
+++ b/deploy/dev/multi-dc/test/cr-secondary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-secondary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/test/cr-tertiary.yaml
+++ b/deploy/dev/multi-dc/test/cr-tertiary.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault-tertiary"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/dev/multi-dc/test/multi-dc-raft.sh
+++ b/deploy/dev/multi-dc/test/multi-dc-raft.sh
@@ -72,7 +72,7 @@ function infra_setup {
 
     node_setup tertiary 172.18.3.255/25
 
-    docker run -d --rm --network kind -e VAULT_DEV_ROOT_TOKEN_ID="${VAULT_TOKEN}" --name central-vault vault:"${VAULT_VERSION}"
+    docker run -d --rm --network kind -e VAULT_DEV_ROOT_TOKEN_ID="${VAULT_TOKEN}" --name central-vault hashicorp/vault:"${VAULT_VERSION}"
     CENTRAL_VAULT_ADDRESS=$(docker inspect central-vault --format '{{.NetworkSettings.Networks.kind.IPAddress}}')
     export CENTRAL_VAULT_ADDRESS
 }

--- a/deploy/examples/cr-alibaba.yaml
+++ b/deploy/examples/cr-alibaba.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Describe where you would like to store the Vault unseal keys and root token
   # in OSS encrypted with KMS.

--- a/deploy/examples/cr-audit.yaml
+++ b/deploy/examples/cr-audit.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/examples/cr-aws-server-side-encryption.yaml
+++ b/deploy/examples/cr-aws-server-side-encryption.yaml
@@ -57,7 +57,7 @@ spec:
             policies: ["allow_secrets", "allow_pki"]
             ttl: 1h
 
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # It's always a good idea to specify
   resources:

--- a/deploy/examples/cr-aws.yaml
+++ b/deploy/examples/cr-aws.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Instead of credentialsConfig one can use IAM instance profiles, or kube2iam for example:
   annotations:

--- a/deploy/examples/cr-awskms.yaml
+++ b/deploy/examples/cr-awskms.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:main
 
   serviceAccount: vault

--- a/deploy/examples/cr-azure.yaml
+++ b/deploy/examples/cr-azure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Describe where you would like to store the Vault unseal keys and root token
   # in Azure KeyVault.

--- a/deploy/examples/cr-cert-manager.yaml
+++ b/deploy/examples/cr-cert-manager.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.0
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running

--- a/deploy/examples/cr-containers.yaml
+++ b/deploy/examples/cr-containers.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   # specify a custom bank-vaults image with bankVaultsImage:
   # bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
 

--- a/deploy/examples/cr-credentialFromSecret.yaml
+++ b/deploy/examples/cr-credentialFromSecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-customports.yaml
+++ b/deploy/examples/cr-customports.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-disabled-root-token-storage.yaml
+++ b/deploy/examples/cr-disabled-root-token-storage.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   # specify a custom bank-vaults image with bankVaultsImage:
   # bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
 

--- a/deploy/examples/cr-file.yaml
+++ b/deploy/examples/cr-file.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:main
 
   serviceAccount: vault

--- a/deploy/examples/cr-gcpkms.yaml
+++ b/deploy/examples/cr-gcpkms.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:main
 
   serviceAccount: vault

--- a/deploy/examples/cr-gcs-ha-autounseal.yaml
+++ b/deploy/examples/cr-gcs-ha-autounseal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Describe where you would like to store the Vault unseal keys and root token
   # in GCS encrypted with KMS.

--- a/deploy/examples/cr-gcs-ha.yaml
+++ b/deploy/examples/cr-gcs-ha.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Describe where you would like to store the Vault unseal keys and root token
   # in GCS encrypted with KMS.

--- a/deploy/examples/cr-hsm-nitrokey.yaml
+++ b/deploy/examples/cr-hsm-nitrokey.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-hsm-softhsm.yaml
+++ b/deploy/examples/cr-hsm-softhsm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-init-containers.yaml
+++ b/deploy/examples/cr-init-containers.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-istio.yaml
+++ b/deploy/examples/cr-istio.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.3.1
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:main
 
   # Common annotations for all created resources

--- a/deploy/examples/cr-k8s-startup-secret.yaml
+++ b/deploy/examples/cr-k8s-startup-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-kvv2.yaml
+++ b/deploy/examples/cr-kvv2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the Service's type where the Vault Service is exposed
   serviceType: ClusterIP

--- a/deploy/examples/cr-mysql-ha.yaml
+++ b/deploy/examples/cr-mysql-ha.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/examples/cr-nodeAffinity.yaml
+++ b/deploy/examples/cr-nodeAffinity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 3
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # A YAML representation of nodeAffinity
   # Detail can reference: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/deploy/examples/cr-oidc.yaml
+++ b/deploy/examples/cr-oidc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/examples/cr-podAntiAffinity.yaml
+++ b/deploy/examples/cr-podAntiAffinity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 3
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Set use which node label for pod anti-affinity. Prevent all vault put on same AZ.
   # Detail can reference: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/deploy/examples/cr-policy-with-accessor.yaml
+++ b/deploy/examples/cr-policy-with-accessor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.10.0
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/examples/cr-priority.yaml
+++ b/deploy/examples/cr-priority.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   vaultPodSpec:
     priorityClassName: high-priority

--- a/deploy/examples/cr-prometheus.yaml
+++ b/deploy/examples/cr-prometheus.yaml
@@ -11,7 +11,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/deploy/examples/cr-raft-1.yaml
+++ b/deploy/examples/cr-raft-1.yaml
@@ -7,7 +7,7 @@ metadata:
     vault_cr: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-raft-ha-storage.yaml
+++ b/deploy/examples/cr-raft-ha-storage.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 3
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
 
   # Schedule the pods on the same node, since we are using hostPath storage

--- a/deploy/examples/cr-raft.yaml
+++ b/deploy/examples/cr-raft.yaml
@@ -7,7 +7,7 @@ metadata:
     vault_cr: vault
 spec:
   size: 3
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Common annotations for all created resources
   annotations:

--- a/deploy/examples/cr-resource.yaml
+++ b/deploy/examples/cr-resource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   resources:
     # A YAML representation of resource ResourceRequirements for vault container

--- a/deploy/examples/cr-statsd.yaml
+++ b/deploy/examples/cr-statsd.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the Service's type where the Vault Service is exposed
   serviceType: ClusterIP

--- a/deploy/examples/cr-transit-unseal.yaml
+++ b/deploy/examples/cr-transit-unseal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: default
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults
   # configurer/unsealer will be running
@@ -166,7 +166,7 @@ metadata:
   namespace: tenant
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults
   # configurer/unsealer will be running

--- a/deploy/examples/cr-vault-kv-unseal.yaml
+++ b/deploy/examples/cr-vault-kv-unseal.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "vault-kv-unseal"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
 
   # Describe where you would like to store the Vault unseal keys and root token
   # in seperate remote Vault instance.

--- a/deploy/examples/cr.yaml
+++ b/deploy/examples/cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.6.2
+  image: hashicorp/vault:1.13.3
   # specify a custom bank-vaults image with bankVaultsImage:
   # bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:latest
 

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -63,7 +63,7 @@ type VaultSpec struct {
 	Size int32 `json:"size,omitempty"`
 
 	// Image specifies the Vault image to use for the Vault instances
-	// default: library/hashicorp/vault:latest
+	// default: hashicorp/vault:latest
 	Image string `json:"image,omitempty"`
 
 	// BankVaultsImage specifies the Bank Vaults image to use for Vault unsealing and configuration

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -445,7 +445,7 @@ func (spec *VaultSpec) getListener() map[string]interface{} {
 // GetVaultImage returns the Vault image to use
 func (spec *VaultSpec) GetVaultImage() string {
 	if spec.Image == "" {
-		return "vault:latest"
+		return "hashicorp/vault:latest"
 	}
 	return spec.Image
 }

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -63,7 +63,7 @@ type VaultSpec struct {
 	Size int32 `json:"size,omitempty"`
 
 	// Image specifies the Vault image to use for the Vault instances
-	// default: library/vault:latest
+	// default: library/hashicorp/vault:latest
 	Image string `json:"image,omitempty"`
 
 	// BankVaultsImage specifies the Bank Vaults image to use for Vault unsealing and configuration

--- a/test/acceptance_test.go
+++ b/test/acceptance_test.go
@@ -366,7 +366,7 @@ func prepareEnv(t *testing.T, testName string, k8sRes []string) *k8s.KubectlOpti
 		if v.(map[string]interface{})["kind"] == "Vault" {
 			if i, ok := v.(map[string]interface{})["spec"].(map[string]interface{}); ok {
 				if i["image"] != "" {
-					i["image"] = "vault:" + vaultVersion
+					i["image"] = "hashicorp/vault:" + vaultVersion
 				}
 			}
 

--- a/test/deploy/test-external-secrets-watch-deployment.yaml
+++ b/test/deploy/test-external-secrets-watch-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:1.2.3
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Common annotations for all created resources


### PR DESCRIPTION
## Overview

Fixes https://github.com/bank-vaults/vault-operator/issues/116

Hashicorp has deprecated Duplicative Docker Images (see https://developer.hashicorp.com/vault/docs/v1.13.x/deprecation).
New versions of vault are only published to https://hub.docker.com/hashicorp/vault.
https://hub.docker.com/_/vault only contains old versions up to 1.13.3.

Also updated default Vault image version
