### PR TITLE
chore: use bankVaults.image.tag chart value

### DIFF
--- a/deploy/dev/multi-dc/aws/multi-dc-raft.sh
+++ b/deploy/dev/multi-dc/aws/multi-dc-raft.sh
@@ -91,7 +91,7 @@ if [ $COMMAND = "install" ]; then
 
         local REGION=$(get_region)
 
-        helm upgrade --install vault-operator deploy/charts/vault-operator --wait --set image.tag=latest --set image.pullPolicy=Always --set image.bankVaultsTag=latest
+        helm upgrade --install vault-operator deploy/charts/vault-operator --wait --set image.tag=latest --set image.pullPolicy=Always --set bankVaults.image.tag=latest
 
         create_aws_secret
 
@@ -143,13 +143,13 @@ elif [ $COMMAND = "status" ]; then
 
     aws s3api get-object --bucket ${BUCKET} --key raft-vault-root raft-vault-root > /dev/null
     export VAULT_TOKEN=$(aws --region $REGION kms decrypt --ciphertext-blob fileb://raft-vault-root --query Plaintext --output text --encryption-context Tool=bank-vaults | base64 -D)
-    
+
     rm raft-vault-root
 
     export VAULT_SKIP_VERIFY="true"
 
     export VAULT_ADDR=https://$(get_elb_dns):8200
-    
+
     vault operator raft list-peers -format json | jq
 
 elif [ $COMMAND = "uninstall" ]; then

--- a/deploy/dev/multi-dc/test/multi-dc-raft.sh
+++ b/deploy/dev/multi-dc/test/multi-dc-raft.sh
@@ -82,7 +82,7 @@ function install_instance {
 
     kind load image-archive docker.tar --name "${INSTANCE}"
 
-    helm upgrade --install vault-operator ./deploy/charts/vault-operator --wait --set image.tag=${OPERATOR_VERSION} --set image.pullPolicy=Never --set image.bankVaultsTag=${BANK_VAULTS_VERSION}
+    helm upgrade --install vault-operator ./deploy/charts/vault-operator --wait --set image.tag=${OPERATOR_VERSION} --set image.pullPolicy=Never --set bankVaults.image.tag=${BANK_VAULTS_VERSION}
 
     kubectl apply -k deploy/rbac/
     envtpl deploy/dev/multi-dc/test/cr-"${INSTANCE}".yaml | kubectl apply -f -

--- a/test/acceptance_test.go
+++ b/test/acceptance_test.go
@@ -84,9 +84,9 @@ func TestMain(m *testing.M) {
 	helmOptions := &helm.Options{
 		KubectlOptions: defaultKubectlOptions,
 		SetValues: map[string]string{
-			"image.tag":           operatorVersion,
-			"image.bankVaultsTag": bankVaultsVersion,
-			"image.pullPolicy":    "Never",
+			"image.tag":            operatorVersion,
+			"image.pullPolicy":     "Never",
+			"bankVaults.image.tag": bankVaultsVersion,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Use bankVaults.image.tag chart value instead of deprecated image.bankVaultsTag (see [here](https://github.com/bank-vaults/vault-operator/blob/bfe2f36aae911f57b04f6dfba4a6b9f36c163fb4/deploy/charts/vault-operator/values.yaml#L27) and [here](https://github.com/bank-vaults/vault-operator/blob/bfe2f36aae911f57b04f6dfba4a6b9f36c163fb4/deploy/charts/vault-operator/README.md?plain=1#L23)).

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

<!-- Anything the reviewer should know? -->
