### PR TITLE
Make lease parameters manually settable trough env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /bin/
 /build/
 /tmp/
+.idea
+.vscode
+*.out


### PR DESCRIPTION
## Overview

As a user, I'd like to manage the lease parameters of the manager by myself to fine-tune lease management inside my cluster.

Three new env vars are thus added to the operator:

1. `LEASE_DURATION` - Default value: 15s
2. `RENEW_DEADLINE` -  Default value: 10s
3. `RETRY_PERIOD` - Default value: 2s
