### PR TITLE
fix: make HSM pin an optional argument to allow setting it via the BANK_VAULTS_HSM_PIN env var

### DIFF
--- a/deploy/charts/vault-operator/crds/crd.yaml
+++ b/deploy/charts/vault-operator/crds/crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vaults.vault.banzaicloud.com
 spec:
   group: vault.banzaicloud.com
@@ -1150,7 +1150,6 @@ spec:
                     required:
                     - keyLabel
                     - modulePath
-                    - pin
                     type: object
                   kubernetes:
                     properties:
@@ -2004,6 +2003,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -2646,6 +2647,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -3295,6 +3298,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -4848,6 +4853,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  restartPolicy:
+                    type: string
                   securityContext:
                     properties:
                       allowPrivilegeEscalation:
@@ -5465,6 +5472,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -6147,6 +6156,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -7141,6 +7152,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -7783,6 +7796,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -8432,6 +8447,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:

--- a/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
+++ b/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vaults.vault.banzaicloud.com
 spec:
   group: vault.banzaicloud.com
@@ -1150,7 +1150,6 @@ spec:
                     required:
                     - keyLabel
                     - modulePath
-                    - pin
                     type: object
                   kubernetes:
                     properties:
@@ -2004,6 +2003,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -2646,6 +2647,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -3295,6 +3298,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -4848,6 +4853,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  restartPolicy:
+                    type: string
                   securityContext:
                     properties:
                       allowPrivilegeEscalation:
@@ -5465,6 +5472,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -6147,6 +6156,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -7141,6 +7152,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -7783,6 +7796,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -8432,6 +8447,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -781,9 +781,14 @@ func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 			fmt.Sprint(usc.HSM.SlotID),
 			"--hsm-key-label",
 			usc.HSM.KeyLabel,
-			"--hsm-pin",
-			usc.HSM.Pin,
 		)
+
+		if usc.HSM.Pin != "" {
+			args = append(args,
+				"--hsm-pin",
+				usc.HSM.Pin,
+			)
+		}
 
 		if usc.HSM.TokenLabel != "" {
 			args = append(args,
@@ -908,6 +913,7 @@ type HSMUnsealConfig struct {
 	ModulePath string `json:"modulePath"`
 	SlotID     uint   `json:"slotId,omitempty"`
 	TokenLabel string `json:"tokenLabel,omitempty"`
+	// +optional
 	Pin        string `json:"pin"`
 	KeyLabel   string `json:"keyLabel"`
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Previously, the pin had to be provided by the user in their Vault yaml. If you want to keep the pin secret in
source code, then this isn't desirable. Viper defaults to the command line version of the pin, so even if you
set a dummy pin in the yaml and override it via `envsConfig`, bank-vaults won't use the right pin.

## Notes for reviewer

This is my first PR here so please check if I missed things that need to be updated.