### PR TITLE
fix: Use correct label name for ServiceMonitor jobLabel field

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -652,7 +652,7 @@ func serviceMonitorForVault(v *vaultv1alpha1.Vault) *monitorv1.ServiceMonitor {
 			Labels:    ls,
 		},
 		Spec: monitorv1.ServiceMonitorSpec{
-			JobLabel: v.Name,
+			JobLabel: "vault_cr",
 			Selector: metav1.LabelSelector{
 				MatchLabels: ls,
 				MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #366 

## Notes for reviewer

This just sets the `jobLabel` in the `ServiceMonitorSpec` to the label name that contains the Vault custom resource name on the Service (which is hard-coded [here](https://github.com/bank-vaults/vault-operator/blob/main/pkg/apis/vault/v1alpha1/vault_types.go#L1024)).
<!-- Anything the reviewer should know? -->
