### PR TITLE
fix: Skip CA Secret Upsert for Namespace in Terminating state

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -2100,6 +2100,10 @@ func (r *ReconcileVault) distributeCACertificate(ctx context.Context, v *vaultv1
 		}
 
 		for _, namespace := range namespaceList.Items {
+			// Skip the namespace if it's being deleted
+			if namespace.DeletionTimestamp != nil {
+				continue
+			}
 			namespaces = append(namespaces, namespace.Name)
 		}
 	} else {


### PR DESCRIPTION
Issue - Vault-Operator fails to create vault-tls secret for new namespaces if any existing namespace is in Terminating State.

Fix -> Skip the namespaces in terminating state.