### PR TITLE
feat: Add option to allow TLS termination by load balancers

### DIFF
--- a/deploy/charts/vault-operator/crds/crd.yaml
+++ b/deploy/charts/vault-operator/crds/crd.yaml
@@ -775,6 +775,8 @@ spec:
                 type: string
               raftLeaderAddress:
                 type: string
+              raftLeaderApiSchemeOverride:
+                type: string
               resources:
                 properties:
                   bankVaults:

--- a/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
+++ b/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
@@ -775,6 +775,8 @@ spec:
                 type: string
               raftLeaderAddress:
                 type: string
+              raftLeaderApiSchemeOverride:
+                type: string
               resources:
                 properties:
                   bankVaults:

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -206,6 +206,11 @@ type VaultSpec struct {
 	// default: ""
 	RaftLeaderAddress string `json:"raftLeaderAddress,omitempty"`
 
+	// RaftLeaderApiSchemeOverride will override the value provided from TLS defined values in order
+	// to handle TLS being terminated by an external reverse proxy, load balancer, etc.
+	// default: ""
+	RaftLeaderApiSchemeOverride string `json:"raftLeaderApiSchemeOverride,omitempty"`
+
 	// ServicePorts is an extra map of ports that should be exposed by the Vault Service.
 	// default:
 	ServicePorts map[string]int32 `json:"servicePorts,omitempty"`

--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -1163,11 +1163,15 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 
 	if v.Spec.IsRaftStorage() {
 		raftLeaderAddress := v.Name
+		raftApiScheme := v.Spec.GetAPIScheme()
 		if v.Spec.IsRaftBootstrapFollower() {
 			raftLeaderAddress = v.Spec.RaftLeaderAddress
+			if v.Spec.RaftLeaderApiSchemeOverride != "" {
+				raftApiScheme = v.Spec.RaftLeaderApiSchemeOverride
+			}
 		}
 
-		unsealCommand = append(unsealCommand, "--raft", "--raft-leader-address", v.Spec.GetAPIScheme()+"://"+raftLeaderAddress+":8200")
+		unsealCommand = append(unsealCommand, "--raft", "--raft-leader-address", raftApiScheme+"://"+raftLeaderAddress+":8200")
 
 		if v.Spec.IsRaftBootstrapFollower() {
 			unsealCommand = append(unsealCommand, "--raft-secondary")


### PR DESCRIPTION
## Overview

This feature allows the operator to use an override for API Scheme (http/https) when calling the Raft leader. If the user does not want to use TLS within Vault, but rather have a reverse proxy and/or load balancer terminate the connection, this override allows `http` or `https` to be added to the `raftLeaderAddress`. By default, this API Scheme is set based upon values provided in the Vault config for TLS. This is non-intrusive and will only override the `raftLeaderAddress` value if provided.