### PR TITLE
fix: Add a tokenreviews role to the leader-election-role

### DIFF
--- a/deploy/rbac/leader_election_role.yaml
+++ b/deploy/rbac/leader_election_role.yaml
@@ -42,3 +42,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
## Overview

With Kubernetes 1.24 and later, short-lived tokens are now a "thing". This change allows the leader-election role to conduct token reviews in line with the advice on [this page](https://developer.hashicorp.com/vault/docs/auth/kubernetes#how-to-work-with-short-lived-kubernetes-tokens)

## Notes for reviewer

Without this, you may see errors like this: `cannot create resource "tokenreviews" in API group` (see [this KB article](https://support.hashicorp.com/hc/en-us/articles/8231471929491-Getting-the-error-cannot-create-resource-tokenreviews-in-API-group-during-Kubernetes-Authentication) too)