### PR TITLE
fix: Add mergo.WithAppendSlice for VaultConfigurerPodSpec

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -948,7 +948,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 	// merge provided VaultConfigurerPodSpec into the PodSpec defined above
 	// the values in VaultConfigurerPodSpec will never overwrite fields defined in the PodSpec above
 	if v.Spec.VaultConfigurerPodSpec != nil {
-		if err := mergo.Merge(&podSpec, corev1.PodSpec(*v.Spec.VaultConfigurerPodSpec)); err != nil {
+		if err := mergo.Merge(&podSpec, corev1.PodSpec(*v.Spec.VaultConfigurerPodSpec), mergo.WithAppendSlice); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Overview

Hi team,

We want to be able to override some fields of the `bank-vaults` container in the `vault-configurer` deployment. Currently, the operator does not allow merging of the 'containers' array into the predefined PodSpec. 

## Fixes

I've added the mergo.WithAppendSlice argument this `mergo.Merge` function so you are able to override all the fields of the container.

---

I used the following code snipped to test locally using mergo, it may come in handy for you to validate my suggested change:

```
package main

import (
	"fmt"
	"log"

	"dario.cat/mergo"
	"gopkg.in/yaml.v2"
	corev1 "k8s.io/api/core/v1"
)

func main() {
	podSpec := corev1.PodSpec{
		Containers: []corev1.Container{
			{
				Name: "bank-vaults",
			},
		},
	}
	mergeSpec := corev1.PodSpec{
		Containers: []corev1.Container{
			{
				Name: "bank-vaults",
				SecurityContext: &corev1.SecurityContext{
					RunAsUser:  new(int64), // New value
					Privileged: new(bool),  // New value
				},
			},
		},
	}
	// Use mergo with the WithAppendSlice option to merge slices
	if err := mergo.Merge(&podSpec, mergeSpec, mergo.WithAppendSlice); err != nil {
		log.Fatalf("Error merging specs: %v", err)
	}
	yamlData, err := yaml.Marshal(podSpec)
	if err != nil {
		log.Fatalf("Error marshaling to YAML: %v", err)
	}

	// Print the YAML to stdout
	fmt.Println(string(yamlData))
}
```