### PR TITLE
feat: reduce test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,8 +214,8 @@ jobs:
     needs: [artifacts]
     strategy:
       matrix:
-        k8s_version: ["v1.24.15", "v1.25.11", "v1.26.6", "v1.27.3"]
-        vault_version: ["1.11.12", "1.12.9", "1.13.5", "1.14.8"] # latest versions with MPL 2.0 license
+        k8s_version: ["v1.28.9", "v1.29.4", "v1.30.0"]
+        vault_version: ["1.14.8"] # latest versions with MPL 2.0 license
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Overview

- This PR reduces the CI acceptance-test matrix, to only test againts the latest vault, and supported K8S versions. 

Fixes #135 

