### PR TITLE
chore: add missing capability to openshift scc example

### DIFF
--- a/deploy/examples/vault-openshift-scc.yaml
+++ b/deploy/examples/vault-openshift-scc.yaml
@@ -14,6 +14,7 @@ allowPrivilegedContainer: false
 defaultAddCapabilities: null
 allowedCapabilities:
 - IPC_LOCK
+- SETFCAP
 allowedUnsafeSysctls: null
 fsGroup:
   type: RunAsAny


### PR DESCRIPTION
## Overview

Add missing `SETFCAP` capability introduced in https://github.com/bank-vaults/vault-operator/commit/4871a3038dc35b40a5db48bf9bf01826e3f4e9c2 to openshift scc example