### PR TITLE
fix: update vault liveness probe to /sys/health for improved reliability

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/blang/semver/v4"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -30,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	vaultv1alpha1 "github.com/bank-vaults/vault-operator/pkg/apis/vault/v1alpha1"
 	bvtls "github.com/bank-vaults/vault-sdk/tls"
 	"github.com/bank-vaults/vault-sdk/vault"

--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/blang/semver/v4"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -29,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	vaultv1alpha1 "github.com/bank-vaults/vault-operator/pkg/apis/vault/v1alpha1"
 	bvtls "github.com/bank-vaults/vault-sdk/tls"
 	"github.com/bank-vaults/vault-sdk/vault"
@@ -1214,13 +1214,13 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 				FailureThreshold: 18,
 			},
 			// This probe makes sure Vault is responsive in a HTTPS manner
-			// See: https://www.vaultproject.io/api/system/init.html
+			// See: https://www.vaultproject.io/api/system/health.html
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: getVaultURIScheme(v),
 						Port:   intstr.FromString(v.Spec.GetAPIPortName()),
-						Path:   "/v1/sys/init",
+						Path:   "/v1/sys/health?standbyok=true",
 					},
 				},
 			},


### PR DESCRIPTION
<!--  
Thank you for submitting a pull request! Here are some tips for contributors:

1. Fill out the template below.
2. Include appropriate tests to verify your changes.
3. Ensure all CI checks have passed before marking the PR as ready for review.
4. If this is a draft PR, use GitHub's "Draft PR" feature.
-->

## Overview

This PR updates the Vault liveness probe from `/v1/sys/init` to `/sys/health`. The `/v1/sys/init` endpoint does not include health status, which can cause Vault to become inaccessible when its health fails. By aligning the liveness probe with the readiness probe to use `/sys/health`, we ensure consistent behavior and improved reliability.

Additionally, this change aligns with the Vault official Helm chart, which also uses `/sys/health` for both readiness and liveness probes, as specified [here](https://github.com/hashicorp/vault-helm/blob/main/values.yaml#L540).

This change comes in response to an issue where Vault stopped responding due to an unhealthy state. The issue required manually deleting the unhealthy pod to restore functionality. By using `/sys/health`, this problem is mitigated as it ensures the liveness probe reflects Vault's actual health.


## Notes for reviewer

- This change improves the resilience of the deployment by ensuring the liveness probe reflects Vault's actual health.
- No additional dependencies were introduced.

Let me know if you’d like further details or adjustments! 😊
