### PR TITLE
feat: add helm release namespace

### DIFF
--- a/deploy/charts/vault-operator/templates/deployment.yaml
+++ b/deploy/charts/vault-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}

--- a/deploy/charts/vault-operator/templates/pdb.yaml
+++ b/deploy/charts/vault-operator/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}

--- a/deploy/charts/vault-operator/templates/psp.yaml
+++ b/deploy/charts/vault-operator/templates/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
@@ -38,6 +39,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.psp.vaultSA }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/deploy/charts/vault-operator/templates/role.yaml
+++ b/deploy/charts/vault-operator/templates/role.yaml
@@ -99,6 +99,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp:{{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - policy
@@ -113,6 +114,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp:{{ .Values.psp.vaultSA }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - policy

--- a/deploy/charts/vault-operator/templates/rolebinding.yaml
+++ b/deploy/charts/vault-operator/templates/rolebinding.yaml
@@ -20,6 +20,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: psp:{{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
 subjects:
@@ -34,6 +35,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: psp:{{ .Values.psp.vaultSA }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
 subjects:

--- a/deploy/charts/vault-operator/templates/sa.yaml
+++ b/deploy/charts/vault-operator/templates/sa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vault-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}

--- a/deploy/charts/vault-operator/templates/service.yaml
+++ b/deploy/charts/vault-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.service.name | default (include "vault-operator.fullname" .)}}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}

--- a/deploy/charts/vault-operator/templates/servicemonitor.yaml
+++ b/deploy/charts/vault-operator/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vault-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add option to deploy resources to Helm release namespace.

Right now all resources are deployed to `default` namespace if not set explicitly with `helm --namespace` flag. This is very confusing. `RBAC `manifests are also tied to `default` namespace but for this i can use `kustomize` or have local copies. For helm chart would be great to stop maintain forked copy.

