### PR TITLE
feat: add keyPrefix field to AzureUnsealConfig

### DIFF
--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -730,6 +730,9 @@ func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 			"--azure-key-vault-name",
 			usc.Azure.KeyVaultName,
 		)
+		if usc.Azure.KeyPrefix != "" {
+			args = append(args, "--azure-key-vault-prefix", usc.Azure.KeyPrefix)
+		}
 	} else if usc.OCI != nil {
 		args = append(args,
 			"--mode",
@@ -927,6 +930,7 @@ type AlibabaUnsealConfig struct {
 // AzureUnsealConfig holds the parameters for Azure Key Vault based unsealing
 type AzureUnsealConfig struct {
 	KeyVaultName string `json:"keyVaultName"`
+	KeyPrefix    string `json:"keyPrefix,omitempty"`
 }
 
 // AWSUnsealConfig holds the parameters for AWS KMS based unsealing


### PR DESCRIPTION
## Overview

Add an optional `keyPrefix` field to `AzureUnsealConfig` that passes `--azure-key-vault-prefix` to bank-vaults. This allows multiple Vault clusters to share a single Azure Key Vault instance without secret name collisions.

**Companion to:** bank-vaults/bank-vaults#3795

### Use case

When multiple independent Vault clusters use the same Azure Key Vault for unseal key storage, the fixed secret names (`vault-recovery-0`, `vault-root`, etc.) collide. With this field, each cluster can use a unique prefix:

```yaml
unsealConfig:
  azure:
    keyVaultName: shared-kv
    keyPrefix: "cluster-a-"
```

This produces secrets named `cluster-a-vault-recovery-0`, `cluster-a-vault-root`, etc.

### Changes

| File | Change |
|------|--------|
| `pkg/apis/vault/v1alpha1/vault_types.go` | Add `KeyPrefix` field to `AzureUnsealConfig`, pass `--azure-key-vault-prefix` in `ToArgs` when set |

### Design

- Field is `omitempty` so existing CRs are unaffected
- Only passes the flag when non-empty, preserving backward compatibility
- Follows the same conditional pattern used by other optional fields in `ToArgs`

## Notes for reviewer

- Depends on bank-vaults/bank-vaults#3795 being merged and released first
- The flag name `--azure-key-vault-prefix` matches the CLI flag added in the companion PR
- No CRD schema regeneration included here; happy to add if needed (please advise on the preferred tool/command)
