### PR TITLE
fix: regenerate CRD to include azure keyPrefix field

### DIFF
--- a/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
+++ b/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
@@ -1349,6 +1349,8 @@ spec:
                     type: object
                   azure:
                     properties:
+                      keyPrefix:
+                        type: string
                       keyVaultName:
                         type: string
                     required:


### PR DESCRIPTION
The `keyPrefix` field was added to `AzureUnsealConfig` in #1071 but `make gen-manifests` was not run, so the CRD schema is missing the field.

This causes server-side validation failures when applying a Vault CR with `keyPrefix` set:

```
.spec.unsealConfig.azure.keyPrefix: field not declared in schema
```

This PR regenerates the CRD via `controller-gen`.