### PR TITLE
fix: configurer not restarting when externalConfig changes

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -970,6 +970,13 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 		}
 	}
 
+	podAnnotations := withPrometheusAnnotations("9091", tlsAnnotations)
+
+	// Annotate the pod template with a hash of externalConfig so that
+	// a change in the configuration triggers a rolling restart of the configurer.
+	externalConfigHash := fmt.Sprintf("%x", sha256.Sum256(v.Spec.ExternalConfigJSON()))
+	podAnnotations["vault.banzaicloud.io/external-config-hash"] = externalConfigHash
+
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        v.Name + "-configurer",
@@ -985,7 +992,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      withVaultConfigurerLabels(v, ls),
-					Annotations: withVaultConfigurerAnnotations(v, withPrometheusAnnotations("9091", tlsAnnotations)),
+					Annotations: withVaultConfigurerAnnotations(v, podAnnotations),
 				},
 				Spec: podSpec,
 			},

--- a/pkg/controller/vault/vault_controller_test.go
+++ b/pkg/controller/vault/vault_controller_test.go
@@ -1071,8 +1071,10 @@ func TestDeploymentForConfigurerExternalConfigHash(t *testing.T) {
 
 	t.Run("same config produces same hash", func(t *testing.T) {
 		config := []byte(`{"auth": [{"type": "kubernetes"}]}`)
-		dep1, _ := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
-		dep2, _ := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		dep1, err := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		assert.NoError(t, err)
+		dep2, err := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		assert.NoError(t, err)
 
 		assert.Equal(t,
 			dep1.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],
@@ -1081,8 +1083,10 @@ func TestDeploymentForConfigurerExternalConfigHash(t *testing.T) {
 	})
 
 	t.Run("different config produces different hash", func(t *testing.T) {
-		dep1, _ := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "kubernetes"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
-		dep2, _ := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "ldap"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		dep1, err := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "kubernetes"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		assert.NoError(t, err)
+		dep2, err := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "ldap"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		assert.NoError(t, err)
 
 		assert.NotEqual(t,
 			dep1.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],

--- a/pkg/controller/vault/vault_controller_test.go
+++ b/pkg/controller/vault/vault_controller_test.go
@@ -1045,3 +1045,48 @@ func TestVaultContainerSpecEnvAppend(t *testing.T) {
 		})
 	}
 }
+
+func TestDeploymentForConfigurerExternalConfigHash(t *testing.T) {
+	baseVaultConfig := []byte(`{"listener": {"tcp": {"address": "127.0.0.1:8200", "tls_disable": 1}}, "storage": {"file": {"path": "/vault/file"}}}`)
+
+	makeVault := func(externalConfig []byte) *vaultv1alpha1.Vault {
+		return &vaultv1alpha1.Vault{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vault", Namespace: "default"},
+			Spec: vaultv1alpha1.VaultSpec{
+				Config:         extv1beta1.JSON{Raw: baseVaultConfig},
+				ExternalConfig: extv1beta1.JSON{Raw: externalConfig},
+			},
+		}
+	}
+
+	t.Run("annotation is present on pod template", func(t *testing.T) {
+		v := makeVault([]byte(`{"auth": [{"type": "kubernetes"}]}`))
+		dep, err := deploymentForConfigurer(v, corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		assert.NoError(t, err)
+
+		hash, ok := dep.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"]
+		assert.True(t, ok, "external-config-hash annotation should be present")
+		assert.NotEmpty(t, hash)
+	})
+
+	t.Run("same config produces same hash", func(t *testing.T) {
+		config := []byte(`{"auth": [{"type": "kubernetes"}]}`)
+		dep1, _ := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		dep2, _ := deploymentForConfigurer(makeVault(config), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+
+		assert.Equal(t,
+			dep1.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],
+			dep2.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],
+		)
+	})
+
+	t.Run("different config produces different hash", func(t *testing.T) {
+		dep1, _ := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "kubernetes"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+		dep2, _ := deploymentForConfigurer(makeVault([]byte(`{"auth": [{"type": "ldap"}]}`)), corev1.ConfigMapList{}, corev1.SecretList{}, map[string]string{})
+
+		assert.NotEqual(t,
+			dep1.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],
+			dep2.Spec.Template.Annotations["vault.banzaicloud.io/external-config-hash"],
+		)
+	})
+}


### PR DESCRIPTION
## Overview

The configurer deployment was not restarting when `externalConfig` content changed in the Vault CR. This meant that updated configuration (secret engines, auth methods, policies, etc.) was written to the configurer Secret but never picked up by the running configurer pod.

This PR adds a SHA-256 hash of `externalConfig` as a pod template annotation (`vault.banzaicloud.io/external-config-hash`). When the config content changes, the hash changes, causing Kubernetes to trigger a rolling restart of the configurer deployment.

Fixes #1083

## Notes for reviewer

This follows the same pattern already used for the Vault StatefulSet, where `vault.banzaicloud.io/vault-config` annotation holds a hash of the raw vault config to trigger restarts on change.