### PR TITLE
fix: add security context skip in vault_controller

### DIFF
--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -1226,7 +1226,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 					Value: fmt.Sprintf("%s://$(VAULT_K8S_POD_NAME).%s.svc:%d", strings.ToLower(string(getVaultURIScheme(v))), v.Namespace, v.Spec.GetAPIPort()),
 				},
 			})))),
-			SecurityContext: withContainerSecurityContext(),
+			SecurityContext: withContainerSecurityContext(v),
 			// This probe allows Vault extra time to be responsive in a HTTPS manner during startup
 			// See: https://www.vaultproject.io/api/system/init.html
 			StartupProbe: &corev1.Probe{
@@ -1983,7 +1983,12 @@ func withNamespaceEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.Env
 	}...)
 }
 
-func withContainerSecurityContext() *corev1.SecurityContext {
+func withContainerSecurityContext(v *vaultv1alpha1.Vault) *corev1.SecurityContext {
+	// When platform-managed security context is enabled, let the platform (e.g. OpenShift SCC)
+	// own the container security context instead of injecting capabilities it may forbid.
+	if v.Spec.PlatformManagedSecurityContext {
+		return nil
+	}
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
 			Add: []corev1.Capability{"IPC_LOCK", "SETFCAP"},


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Fixes an oversight which caused security context to be config-managed (setting IPC_LOCK and SETFCAP), despite PlatformManagerSecurityContext being enabled. Previously we relied on disable_mlock to get an empty security context in vault_controller, but this was removed as part of https://github.com/bank-vaults/vault-operator/commit/9b5d5d2ace44548d4fdf728213a83e6e8bdba701

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

Related to https://github.com/bank-vaults/vault-operator/pull/985

<!-- Anything the reviewer should know? -->
