### PR TITLE
feat: add skipVaultContainerCapabilities for PSS restricted vault container

### DIFF
--- a/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
+++ b/deploy/crd/bases/vault.banzaicloud.com_vaults.yaml
@@ -1279,6 +1279,8 @@ spec:
                 type: integer
               skipEntrypointSetup:
                 type: boolean
+              skipVaultContainerCapabilities:
+                type: boolean
               statsdConfig:
                 type: string
               statsdDisabled:

--- a/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/pkg/apis/vault/v1alpha1/vault_types.go
@@ -200,6 +200,15 @@ type VaultSpec struct {
 	// default: false
 	PlatformManagedSecurityContext bool `json:"platformManagedSecurityContext,omitempty"`
 
+	// SkipVaultContainerCapabilities, when set to true, stops the operator from adding the
+	// IPC_LOCK and SETFCAP capabilities to the vault container. These capabilities only enable
+	// memory locking (mlock); when mlock is disabled they are unnecessary and prevent the vault
+	// container from satisfying the Pod Security Standards "restricted" profile (the injected add
+	// cannot be removed via vaultContainerSpec, which appends). Unlike PlatformManagedSecurityContext,
+	// the pod security context is left untouched.
+	// default: false
+	SkipVaultContainerCapabilities bool `json:"skipVaultContainerCapabilities,omitempty"`
+
 	// SkipEntrypointSetup sets SKIP_CHOWN=true and SKIP_SETCAP=true on the vault container,
 	// bypassing entrypoint steps that fail when vault runs as non-root. Tri-state: nil = auto
 	// (enabled only for Vault 2.0.0, which has a fatal-chown bug); true/false explicitly override.

--- a/pkg/controller/vault/vault_controller.go
+++ b/pkg/controller/vault/vault_controller.go
@@ -1989,6 +1989,13 @@ func withContainerSecurityContext(v *vaultv1alpha1.Vault) *corev1.SecurityContex
 	if v.Spec.PlatformManagedSecurityContext {
 		return nil
 	}
+	// IPC_LOCK and SETFCAP are only needed to support memory locking (mlock). When the operator
+	// is told to skip them, return an empty security context so the vault container can meet the
+	// PodSecurity "restricted" profile — the injected add would otherwise be forbidden and cannot
+	// be removed via vaultContainerSpec, whose capabilities merge appends.
+	if v.Spec.SkipVaultContainerCapabilities {
+		return &corev1.SecurityContext{}
+	}
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
 			Add: []corev1.Capability{"IPC_LOCK", "SETFCAP"},

--- a/pkg/controller/vault/vault_controller_test.go
+++ b/pkg/controller/vault/vault_controller_test.go
@@ -953,6 +953,71 @@ func TestVaultPodSpecContainerMerge(t *testing.T) {
 	}
 }
 
+func TestWithContainerSecurityContextCapabilities(t *testing.T) {
+	baseVaultConfig := []byte(`{"listener": {"tcp": {"address": "127.0.0.1:8200", "tls_disable": 1}}, "storage": {"file": {"path": "/vault/file"}}}`)
+	service := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	tests := []struct {
+		name                           string
+		skipVaultContainerCapabilities bool
+		platformManagedSecurityContext bool
+		validate                       func(t *testing.T, vault corev1.Container)
+	}{
+		{
+			name: "default - IPC_LOCK and SETFCAP added",
+			validate: func(t *testing.T, vault corev1.Container) {
+				assert.NotNil(t, vault.SecurityContext, "security context should be set")
+				assert.NotNil(t, vault.SecurityContext.Capabilities, "capabilities should be set")
+				assert.Equal(t, []corev1.Capability{"IPC_LOCK", "SETFCAP"}, vault.SecurityContext.Capabilities.Add)
+			},
+		},
+		{
+			name:                           "skipVaultContainerCapabilities - no capabilities injected",
+			skipVaultContainerCapabilities: true,
+			validate: func(t *testing.T, vault corev1.Container) {
+				assert.NotNil(t, vault.SecurityContext, "security context should still be set")
+				assert.Nil(t, vault.SecurityContext.Capabilities, "no capabilities should be injected")
+			},
+		},
+		{
+			name:                           "platformManagedSecurityContext - no container security context",
+			platformManagedSecurityContext: true,
+			validate: func(t *testing.T, vault corev1.Container) {
+				assert.Nil(t, vault.SecurityContext, "container security context should be nil")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &vaultv1alpha1.Vault{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vault",
+					Namespace: "default",
+				},
+				Spec: vaultv1alpha1.VaultSpec{
+					Size:                           1,
+					Config:                         extv1beta1.JSON{Raw: baseVaultConfig},
+					SkipVaultContainerCapabilities: tt.skipVaultContainerCapabilities,
+					PlatformManagedSecurityContext: tt.platformManagedSecurityContext,
+				},
+			}
+
+			sts, err := statefulSetForVault(v, []corev1.Secret{}, map[string]string{}, service)
+			assert.NoError(t, err)
+			assert.NotNil(t, sts)
+
+			vault, found := seqs.First(seqs.Filter(seqs.FromSlice(sts.Spec.Template.Spec.Containers), func(c corev1.Container) bool { return c.Name == "vault" }))
+			assert.True(t, found, "vault container should exist")
+			tt.validate(t, vault)
+		})
+	}
+}
+
 func TestVaultContainerSpecEnvAppend(t *testing.T) {
 	baseVaultConfig := []byte(`{"listener": {"tcp": {"address": "127.0.0.1:8200", "tls_disable": 1}}, "storage": {"file": {"path": "/vault/file"}}}`)
 	service := &corev1.Service{


### PR DESCRIPTION
## Overview

The operator always injects `IPC_LOCK` and `SETFCAP` onto the `vault` container in `withContainerSecurityContext()`. Because the `VaultContainerSpec` merge uses `mergo.WithAppendSlice`, `capabilities.add` is appended rather than replaced, so these cannot be removed from the CR. The `vault` container therefore cannot satisfy the Pod Security Standards **restricted** profile (which forbids adding any capability except `NET_BIND_SERVICE`) — even though the operator-injected sidecars can now be hardened via `vaultPodSpec` (#1022).

These capabilities only enable memory locking (`mlock`); when `disable_mlock` is set they are unnecessary. This adds an **opt-in** spec field `skipVaultContainerCapabilities` (default `false`, so existing behavior is unchanged) that returns an empty container security context, letting operators running `disable_mlock` meet the restricted profile. Unlike `platformManagedSecurityContext`, the pod-level security context is left untouched.

For context, v1.23.4 had a `disable_mlock` gate in this function that returned an empty security context; it was removed in `9b5d5d2a` (v1.24.0). This is a minimal, opt-in way to make the vault container restricted-compliant again without changing defaults.

Relates to #314, #231, #942.

## Notes for reviewer

- Default is `false` → no behavior change for existing users.
- Validated end-to-end: with this build + `skipVaultContainerCapabilities: true` + `disable_mlock: true` in a `pod-security.kubernetes.io/enforce: restricted` namespace, `vault-0` reaches **2/2 Running** and the vault container renders `securityContext.capabilities: {drop: [ALL]}` (no `add`). Without the flag, the pod is rejected at admission: `pods "vault-0" is forbidden: violates PodSecurity "restricted:latest": unrestricted capabilities (container "vault" must not include "IPC_LOCK", "SETFCAP" in securityContext.capabilities.add)`.
- `make generate` regenerated the CRD; `make test` and `make lint-go` pass. Test added in `pkg/controller/vault/vault_controller_test.go` (`TestWithContainerSecurityContextCapabilities`) covering default / skip / platform-managed.
- Happy to adjust the shape if you prefer — e.g. gating on the effective `disable_mlock` rather than a new field, or a tri-state `*bool`. I went with an opt-in bool to avoid changing defaults.
